### PR TITLE
[FEAT]: Use Contentful as CMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# ENV files
+src/environments/contentful.environment.ts

--- a/config.index.ts
+++ b/config.index.ts
@@ -1,0 +1,16 @@
+import { writeFile } from 'fs';
+
+const targetPath = './src/environments/environment.prod.ts';
+const envConfigFile = `export const environment = {
+  production: true,
+  contentful: {
+    spaceId: '${process.env.CONTENTFUL_SPACE_ID}',
+    accessToken: '${process.env.CONTENTFUL_ACCESS_TOKEN}'
+  }
+};`;
+
+writeFile(targetPath, envConfigFile, 'utf8', (error) => {
+  if (error) {
+    return console.log(error);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4233,6 +4233,32 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -5705,6 +5731,35 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
+    },
+    "contentful": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-7.14.6.tgz",
+      "integrity": "sha512-7/Xqw/UT0/zW9DeVGAwtW4twGbThIc6rbLATrhUn7AXt/xTCFzgPiJxHgRU9gmr733q/Wckv663B51abDMS9Nw==",
+      "requires": {
+        "axios": "^0.19.1",
+        "contentful-resolve-response": "^1.2.2",
+        "contentful-sdk-core": "^6.4.5",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "contentful-resolve-response": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.2.2.tgz",
+      "integrity": "sha512-KyRz05f2YFJDSFs/L5jtsptbL5Fk3+ukSjRF94zFXq0FOtYoaxyCbqKgHhK2+3hlipxVQ+KGRus/tSaD6PoPMg==",
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "contentful-sdk-core": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.4.5.tgz",
+      "integrity": "sha512-rygNuiwbG6UKrJg6EDlaKewayTeLWrjA2wJwVmq7rV/DYo0cic6t28y0EMhRQ4pgJDV5HyUQFoFeBm2lwLfG2Q==",
+      "requires": {
+        "lodash": "^4.17.10",
+        "qs": "^6.5.2"
+      }
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -10873,8 +10928,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.3",
@@ -11345,8 +11399,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._isnative": {
       "version": "2.4.1",
@@ -12099,8 +12152,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -14111,8 +14163,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "ci:build": "ng build --prod",
+    "config:env": "ts-node -O '{\"module\": \"commonjs\"}' ./config.index.ts",
+    "ci:build": "npm run config:env && ng build --prod",
     "ci:hosting": "firebase deploy --only hosting:studio-splashink"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-browser": "^9.0.0",
     "@angular/platform-browser-dynamic": "^9.0.0",
     "@angular/router": "^9.0.0",
+    "contentful": "^7.14.6",
     "core-js": "^2.6.11",
     "firebase": "^6.6.2",
     "jquery": "^3.4.1",

--- a/src/app/blog/post/post.component.css
+++ b/src/app/blog/post/post.component.css
@@ -1,0 +1,7 @@
+.post-bg-opacity {
+  background-color: rgba(1, 14, 22, 0.8);
+}
+
+.txt-to-upper-case {
+  text-transform: uppercase;
+}

--- a/src/app/blog/post/post.component.html
+++ b/src/app/blog/post/post.component.html
@@ -1,15 +1,14 @@
-<ng-container *ngIf="doc$; else isEmpty">
   <section #sec class="wow fadeIn parallax" data-stellar-background-ratio="0.5">
     <div class="opacity-extra-medium post-bg-opacity"></div>
     <div class="container width-60">
       <div class="row justify-content-center">
         <div class="col-md-12 col-sm-12 col-xs-12 extra-small-screen display-table page-title-large">
           <div class="display-table-cell vertical-align-middle text-center">
-            <span
-              class="opacity6 alt-font text-extra-light-gray font-weight-600 txt-to-upper-case">{{ doc$?.updatedAt.toDate() | date }}</span>
-            | <span class="font-weight-600 txt-to-upper-case" *ngFor="let t of doc$?.tags"> {{ t }} </span>
-            <h1 class="alt-font text-white font-weight-600 letter-spacing-minus-1">Nós combinamos design, pensamento e
-              técnica.</h1>
+            <span class="opacity6 alt-font text-extra-light-gray font-weight-600 txt-to-upper-case">
+              {{ doc$?.publishDate | date }}
+            </span>
+            | <span class="font-weight-600 txt-to-upper-case"> COUPON CODE: {{ doc$?.coupon }} </span>
+            <h1 class="alt-font text-white font-weight-600 letter-spacing-minus-1">{{ doc$?.title }}</h1>
           </div>
         </div>
       </div>
@@ -24,14 +23,9 @@
             <p><span
                 class="first-letter first-letter-block bg-medium-gray text-extra-dark-gray txt-to-upper-case">{{ startWith }}</span>
             </p>
-            <span [innerHTML]="doc$?.body | mdToHtml"></span>
+            <span [innerHTML]="doc$?.body.substring(1) | mdToHtml"></span>
           </div>
         </div>
       </div>
     </section>
   </article>
-</ng-container>
-
-<ng-template #isEmpty>
-  Is empty!
-</ng-template>

--- a/src/app/blog/post/post.component.ts
+++ b/src/app/blog/post/post.component.ts
@@ -2,26 +2,17 @@ import { Component, OnInit, OnDestroy, ElementRef, ViewChild, Renderer2 } from '
 import { Subscription } from 'rxjs';
 import { PostModel } from './post.model';
 import { SeoService } from '@studio/core';
+import { ContentfulService } from 'app/core/contentful.service';
 
 @Component({
   selector: 'ds-post',
   templateUrl: './post.component.html',
-  styles: [
-    `
-      .post-bg-opacity {
-        background-color: rgba(1, 14, 22, 0.8);
-      }
-
-      .txt-to-upper-case {
-        text-transform: uppercase;
-      }
-    `
-  ]
+  styleUrls: ['./post.component.css']
 })
 export class PostComponent implements OnInit, OnDestroy {
 
   doc$: PostModel;
-  subs: Subscription;
+  subscription: Subscription;
   startWith = '';
 
   @ViewChild('sec') ref: ElementRef;
@@ -29,35 +20,35 @@ export class PostComponent implements OnInit, OnDestroy {
   constructor(
     private readonly seo: SeoService,
     private readonly renderer: Renderer2,
+    private readonly contentfulService: ContentfulService,
   ) { }
 
   ngOnInit() {
-    // this.subs = this.fds.doc$<PostModel>('blog/LYE0cQ2QPfMz3svXiGfW')
-    // .subscribe(doc => {
+    this.subscription = this.contentfulService.getContent('1Fur4hADPKRZatMXbzHBGY')
+    .subscribe((content: PostModel) => {
+      const backgroundImage = 'https:' + content.backgroundImage.fields?.file.url;
 
-    //   this.seo.generateTags({
-    //     title: `Blog :: ${doc.title}`,
-    //     description: 'Leia o artigo completo clicando na ligação.',
-    //     image: doc.thumbnail,
-    //     slug: `blog/${doc.pid}`
-    //   });
+      this.startWith = content.body.charAt(0);
+      this.doc$ = content;
 
-    //   this.renderer
-    //   .setStyle(
-    //     this.ref.nativeElement,
-    //     'background-image',
-    //     `url('${doc?.thumbnail}')`
-    //   );
+      this.seo.generateTags({
+        title: `${content.title} - Blog - Splash Ink Studios`,
+        description: 'Leia o artigo completo clicando na ligação.',
+        image: backgroundImage,
+        slug: `blog/${content.slug}`
+      });
 
-    //   this.startWith = doc.body.charAt(0);
-    //   doc.body.substring(1);
-
-    //   this.doc$ = doc;
-    // });
+      this.renderer
+      .setStyle(
+        this.ref.nativeElement,
+        'background-image',
+        `url(${backgroundImage})`
+      );
+    });
   }
 
   ngOnDestroy(): void {
-    // this.subs.unsubscribe();
+    this.subscription.unsubscribe();
   }
 
 }

--- a/src/app/blog/post/post.model.ts
+++ b/src/app/blog/post/post.model.ts
@@ -1,11 +1,11 @@
-import { firestore } from 'firebase';
-
 export interface PostModel {
-    pid?: string | number;
-    coupon?: string;
-    thumbnail: string;
-    title: string;
-    body: string;
-    tags: Array<string>;
-    updatedAt: firestore.Timestamp;
+  id?: string;
+  title: string;
+  slug: string;
+  backgroundImage: any;
+  body: string;
+  publishDate: Date;
+  coupon?: string;
 }
+
+

--- a/src/app/core/contentful.service.ts
+++ b/src/app/core/contentful.service.ts
@@ -12,7 +12,7 @@ export class ContentfulService {
   private client = contentful.createClient({
     space: environment.contentful.spaceId,
     accessToken: environment.contentful.accessToken
-  })
+  });
 
   constructor() { }
 

--- a/src/app/core/contentful.service.ts
+++ b/src/app/core/contentful.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import * as contentful from 'contentful';
+import { environment } from '@environments/environment';
+import { from } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ContentfulService {
+
+  private client = contentful.createClient({
+    space: environment.contentful.spaceId,
+    accessToken: environment.contentful.accessToken
+  })
+
+  constructor() { }
+
+  getContent(entryId: string) {
+    const promise = this.client.getEntry(entryId);
+
+    return from(promise).pipe(
+      map((entry) => entry.fields)
+    );
+  }
+}

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -5,6 +5,7 @@ import { NavComponent } from './nav/nav.component';
 import { throwIfAlreadyLoaded } from './module-import-guard';
 import { FooterComponent } from './footer/footer.component';
 import { SeoService } from './seo.service';
+import { ContentfulService } from './contentful.service';
 
 @NgModule({
   declarations: [NavComponent, FooterComponent],
@@ -14,7 +15,8 @@ import { SeoService } from './seo.service';
   ],
   exports: [NavComponent, FooterComponent],
   providers: [
-    SeoService
+    SeoService,
+    ContentfulService,
   ]
 })
 export class CoreModule {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,17 +2,11 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
+import { contentfulEnvironment } from './contentful.environment';
+
 export const environment = {
   production: false,
-  firebaseConfig: {
-    apiKey: 'AIzaSyB3c_MRj8E3PmiCivhhGExmFpae6dsEeHQ',
-    authDomain: 'disparos-digital-studio.firebaseapp.com',
-    databaseURL: 'https://disparos-digital-studio.firebaseio.com',
-    projectId: 'disparos-digital-studio',
-    storageBucket: '',
-    messagingSenderId: '280475922937',
-    appId: '1:280475922937:web:0c0ced00bd5729bb'
-  }
+  ...contentfulEnvironment
 };
 
 /*


### PR DESCRIPTION
## Description

Add support for CMS plugins. Consider to use [Contentful](https://www.contentful.com/) APIs.

## Reproduction

- [x] Create a new enterprise account at [Contentful](https://www.contentful.com/).
- [x] Generate a new Entry Space and take the TOKEN.
- [x] Install contentful plugin via npm.
- [x] Add the secrets to the Angular project and Resource Server.
- [x] Add script to update environment variables before production build. 
- [x] Retrieve the latest entry post from Contentful to app.

## Tests

No test has been included for this PR.

## Notes

Closes #44 